### PR TITLE
Fix/pointer correction

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -42,6 +42,7 @@ void	tree_print_extense(t_tree *tree);
 
 // Free functions
 void	token_list_free(t_token *head);
+void	token_no_content_free(t_token *head);
 void	tree_free(t_tree *tree);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -35,10 +35,10 @@ void	tree_print(t_tree *tree, int level);
 void	tree_print_extense(t_tree *tree);
 
 t_tree	*tree_create(t_token *list, t_check *flags);
-t_token	*token_create(char **tokens, t_tokens_type *signal);
+t_token	*token_create(char ***tokens, t_tokens_type *signal);
 t_token	*get_next_token(t_token *token);
 
-void	tree_print_extense(t_tree *tree); 
+void	tree_print_extense(t_tree *tree);
 
 // Free functions
 void	token_list_free(t_token *head);

--- a/includes/token.h
+++ b/includes/token.h
@@ -1,8 +1,6 @@
 #ifndef TOKEN_H
 # define TOKEN_H
 
-#include "minishell.h"
-
 typedef enum e_tokens_type
 {
 	CMD,

--- a/src/free/token_list_free.c
+++ b/src/free/token_list_free.c
@@ -9,14 +9,27 @@ void	token_list_free(t_token *head)
 	while (head)
 	{
 		next = head->next;
-		temp = (char **)head->token;
-		index = 0;
-		while (temp && temp[index] != NULL)
-		{
-			free(temp[index]);
-			index++;
+		if (head->token){
+			temp = (char **)head->token;
+			index = 0;
+			while (temp && temp[index] != NULL)
+			{
+				free(temp[index]);
+				index++;
+			}
 		}
-		//free(head->token);
+		free(head);
+		head = next;
+	}
+}
+
+void	token_no_content_free(t_token *head)
+{
+	t_token	*next;
+
+	while (head)
+	{
+		next = head->next;
 		free(head);
 		head = next;
 	}

--- a/src/free/token_list_free.c
+++ b/src/free/token_list_free.c
@@ -1,13 +1,22 @@
-#include "../includes/minishell.h"
+#include "../../includes/minishell.h"
 
 void	token_list_free(t_token *head)
 {
 	t_token	*next;
+	int		index;
+	char	**temp;
 
 	while (head)
 	{
 		next = head->next;
-		free(head->token);
+		temp = (char **)head->token;
+		index = 0;
+		while (temp && temp[index] != NULL)
+		{
+			free(temp[index]);
+			index++;
+		}
+		//free(head->token);
 		free(head);
 		head = next;
 	}

--- a/src/main.c
+++ b/src/main.c
@@ -22,13 +22,19 @@ int	main(void)
 		//add_history(input);
 		// Hardcode - Lexer vai substituir isso depois
 		t_tokens_type	signal[] = {CMD, FILE_PATH, INPUT, OUTPUT, APPEND, HEREDOC, PIPE, AND, OR, EOFILE};
-		char			*tokens[] = {input, NULL};
+
+		char *tokens = ft_strdup(input);
+		char **pointer_token;
+
+		pointer_token = (char **)ft_calloc(2, sizeof(char *));
+		pointer_token[0] = tokens;
+		pointer_token[1] = NULL;
 		flags.word = 1;
 		flags.input = 0;
 		flags.output = 0;
 		flags.pipe = 0;
 		flags.logical = 0;
-		head = token_create(tokens, signal);
+		head = token_create(&pointer_token, signal);
 		if (!head)
 		{
 			ft_printf("Failed to create token list\n");
@@ -38,9 +44,10 @@ int	main(void)
 		tree = tree_create(head, &flags);
 		ft_printf("You entered: %s\n", input);
 	//	tree_print(tree, 0);
+	//	free(pointer_token);
 		tree_free(tree);
-		token_list_free(head);
-		free(input);
+		//token_list_free(head);
+		//free(input);
 	}
 	return (0);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -43,11 +43,12 @@ int	main(void)
 		}
 		tree = tree_create(head, &flags);
 		ft_printf("You entered: %s\n", input);
-	//	tree_print(tree, 0);
-	//	free(pointer_token);
+		//tree_print(tree, 1);
+		free(tokens);
+		free(pointer_token);
 		tree_free(tree);
-		//token_list_free(head);
-		//free(input);
+		token_no_content_free(head);
+		free(input);
 	}
 	return (0);
 }

--- a/src/token/token_cmd_create.c
+++ b/src/token/token_cmd_create.c
@@ -1,6 +1,7 @@
-#include "../includes/minishell.h"
+#include "../../includes/minishell.h"
+#include <readline/keymaps.h>
 
-static t_token	*token_node(char *token, t_tokens_type signal)
+static t_token	*token_node(char **token, t_tokens_type signal)
 {
 	t_token	*node;
 
@@ -8,12 +9,12 @@ static t_token	*token_node(char *token, t_tokens_type signal)
 	if (!node)
 		return (NULL);
 	node->signal = signal;
-	node->token = ft_strdup(token);
+	node->token = token;
 	node->next = NULL;
 	return (node);
 }
 
-t_token	*token_create(char **tokens, t_tokens_type *signal)
+t_token	*token_create(char ***tokens, t_tokens_type *signal)
 {
 	t_token	*head;
 	t_token	*current;
@@ -24,8 +25,8 @@ t_token	*token_create(char **tokens, t_tokens_type *signal)
 		return (NULL);
 	head = NULL;
 	prev = NULL;
-	index = -1;
-	while (tokens[++index] != NULL)
+	index = 0;
+	while (tokens[index] && tokens[index][0] != NULL)
 	{
 		current = token_node(tokens[index], signal[index]);
 		if (!current)
@@ -38,6 +39,7 @@ t_token	*token_create(char **tokens, t_tokens_type *signal)
 		else
 			prev->next = current;
 		prev = current;
+		index++;
 	}
 	return (head);
 }

--- a/src/tree/tree_build.c
+++ b/src/tree/tree_build.c
@@ -1,4 +1,4 @@
-#include "../includes/minishell.h"
+#include "../../includes/minishell.h"
 
 static t_tree	*tree_node_create(t_tree *left, t_token **token, t_tree *right)
 {
@@ -48,6 +48,7 @@ static t_tree	*tree_redir(t_token **token)
 		return (NULL);
 	cmd_node = NULL;
 	file_node = NULL;
+	token_redir = NULL;
 	if (!(*token)->next || (*token)->next->signal > HEREDOC)
 	{
 		cmd_node = tree_node_create(NULL, token, NULL);

--- a/src/tree/tree_build.c
+++ b/src/tree/tree_build.c
@@ -12,6 +12,7 @@ static t_tree	*tree_node_create(t_tree *left, t_token **token, t_tree *right)
 	tree->left = left;
 	tree->signal = (*token)->signal;
 	tree->node = (*token)->token;
+	(*token)->token = NULL;
 	tree->right = right;
 	*token = (*token)->next;
 	return (tree);

--- a/src/tree/tree_utils.c
+++ b/src/tree/tree_utils.c
@@ -1,4 +1,4 @@
-#include "../includes/minishell.h"
+#include "../../includes/minishell.h"
 
 t_token	*get_next_token(t_token *token)
 {


### PR DESCRIPTION
- Corrections to token pointer from char ** to char *** to be able to carry lists of char **, necessary for execution function.
- Add new free function for empty tokens
- Add safety guard to free token list
- Add necessary free functions to currently flow
- Fix: add NULL pointer to token list after moving pointer to the tree.
- [WARNING] : Compiler still complains about unitialized values on token list. Adding lexer might correct this.