### PR TITLE
Feat/redirect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ val:
 		--leak-check=full \
 		--show-leak-kinds=all \
 		--track-origins=yes \
+		--trace-children=yes \
 		--track-fds=yes		\
 		--suppressions=readline.supp \
 		./$(NAME)

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ SRCS	= \
 		src/lexer/lexer_utils.c	\
 		src/free/envp_free.c	\
 		src/executor/execution_base.c	\
+		src/executor/execution_redir.c	\
 		src/utils/envp.c		\
 		src/utils/envp_rebuilt.c	\
 		src/main.c

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ CC		= cc
 CFLAGS	= -Wall -Werror -Wextra -g3 -I includes
 
 SRCS	= \
+		src/tree/tree_print.c		\
 		src/token/token_cmd_create.c	\
 		src/tree/tree_build.c		\
 		src/tree/tree_utils.c		\

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME	= minishell
 CC		= cc
-CFLAGS	= -Wall -Werror -Wextra -g3 -fsanitize=address -I includes
+CFLAGS	= -Wall -Werror -Wextra -g3 -I includes
 
 SRCS	= \
 		src/lexer/lexer.c			\
@@ -12,6 +12,7 @@ SRCS	= \
 		src/tree/tree_utils.c		\
 		src/executor/execution_base.c	\
 		src/executor/execution_redir.c	\
+		src/executor/execution_utils.c	\
 		src/free/tree_free.c		\
 		src/free/token_list_free.c	\
 		src/free/envp_free.c	\

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ SRCS	= \
 		src/free/token_list_free.c	\
 		src/free/envp_free.c	\
 		src/executor/execution_base.c	\
+		src/executor/execution_redir.c	\
 		src/utils/envp.c		\
 		src/utils/envp_rebuilt.c	\
 		src/main.c

--- a/Makefile
+++ b/Makefile
@@ -3,17 +3,18 @@ CC		= cc
 CFLAGS	= -Wall -Werror -Wextra -g3 -I includes
 
 SRCS	= \
-		src/tree/tree_print.c		\
-		src/token/token_cmd_create.c	\
-		src/tree/tree_build.c		\
-		src/tree/tree_utils.c		\
-		src/free/tree_free.c		\
-		src/free/token_list_free.c	\
 		src/lexer/lexer.c			\
 		src/lexer/lexer_utils.c	\
-		src/free/envp_free.c	\
+		src/token/token_cmd_create.c	\
+		src/parser/parser.c			\
+		src/tree/tree_print.c		\
+		src/tree/tree_build.c		\
+		src/tree/tree_utils.c		\
 		src/executor/execution_base.c	\
 		src/executor/execution_redir.c	\
+		src/free/tree_free.c		\
+		src/free/token_list_free.c	\
+		src/free/envp_free.c	\
 		src/utils/envp.c		\
 		src/utils/envp_rebuilt.c	\
 		src/main.c
@@ -33,6 +34,7 @@ val:
 		--leak-check=full \
 		--show-leak-kinds=all \
 		--track-origins=yes \
+		--track-fds=yes		\
 		--suppressions=readline.supp \
 		./$(NAME)
 
@@ -52,7 +54,10 @@ $(OBJS_DIR)/%.o: src/free/%.c | $(OBJS_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 $(OBJS_DIR)/%.o: src/lexer/%.c | $(OBJS_DIR)
-  $(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(OBJS_DIR)/%.o: src/parser/%.c | $(OBJS_DIR)
+	$(CC) $(CFLAGS) -c $< -o $@
 
 $(OBJS_DIR)/%.o: src/utils/%.c | $(OBJS_DIR)
 	$(CC) $(CFLAGS) -c $< -o $@

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME	= minishell
 CC		= cc
-CFLAGS	= -Wall -Werror -Wextra -g3 -I includes
+CFLAGS	= -Wall -Werror -Wextra -g3 -fsanitize=address -I includes
 
 SRCS	= \
 		src/lexer/lexer.c			\

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -29,6 +29,7 @@ typedef struct s_envp
 //Test Functions
 void	tree_print(t_tree *tree, int level);
 void	tree_print_extense(t_tree *tree);
+void	tokens_print(t_token *token);
 
 // Token Create Functions
 t_tree	*tree_create(t_token *list, t_check *flags);
@@ -38,7 +39,7 @@ t_token	*get_next_token(t_token *token);
 // Free functions
 void	token_list_free(t_token *head);
 void	token_no_content_free(t_token *head);
-void	tree_free(t_tree *tree);
+void	tree_free(t_tree **tree);
 void	tree_node_free(char **node);
 void	envp_free(t_envp **envp);
 void	envp_char_free(char ***envp);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -38,6 +38,7 @@ t_token	*get_next_token(t_token *token);
 void	token_list_free(t_token *head);
 void	token_no_content_free(t_token *head);
 void	tree_free(t_tree *tree);
+void	tree_node_free(char **node);
 void	envp_free(t_envp **envp);
 void	envp_char_free(char ***envp);
 void	split_free(char **split);
@@ -46,6 +47,7 @@ void	split_free(char **split);
 t_envp	*create_envp_table(char **envp);
 
 //Execution
-int execution(t_tree *tree, t_envp *envp);
+int execution(t_tree *tree, t_envp *envp, int *fd);
+int	redirect(t_tree *tree, int *fd);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -48,6 +48,6 @@ t_envp	*create_envp_table(char **envp);
 
 //Execution
 int execution(t_tree *tree, t_envp *envp, int *fd);
-int	redirect(t_tree *tree, int *fd);
+int	redirect(t_tree **tree, int *fd);
 
 #endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -46,9 +46,10 @@ void	split_free(char **split);
 
 // envp function
 t_envp	*create_envp_table(char **envp);
+char	**envp_rebuilt(t_envp *envp_table);
 
 //Execution
-int execution(t_tree *tree, t_envp *envp);
+int execution(t_tree *tree, t_envp *envp_table);
 int	redirect(t_tree **tree, int *fd);
 
 // Lexer functions

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -39,6 +39,7 @@ t_token	*get_next_token(t_token *token);
 void	token_list_free(t_token *head);
 void	token_no_content_free(t_token *head);
 void	tree_free(t_tree *tree);
+void	tree_node_free(char **node);
 void	envp_free(t_envp **envp);
 void	envp_char_free(char ***envp);
 void	split_free(char **split);
@@ -47,7 +48,8 @@ void	split_free(char **split);
 t_envp	*create_envp_table(char **envp);
 
 //Execution
-int execution(t_tree *tree, t_envp *envp);
+int execution(t_tree *tree, t_envp *envp, int *fd);
+int	redirect(t_tree *tree, int *fd);
 
 // Lexer functions
 void	debug_lexer(t_token *list);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -49,7 +49,7 @@ t_envp	*create_envp_table(char **envp);
 
 //Execution
 int execution(t_tree *tree, t_envp *envp, int *fd);
-int	redirect(t_tree *tree, int *fd);
+int	redirect(t_tree **tree, int *fd);
 
 // Lexer functions
 void	debug_lexer(t_token *list);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -52,6 +52,8 @@ char	**envp_rebuilt(t_envp *envp_table);
 //Execution
 int execution(t_tree *tree, t_envp *envp_table);
 int	redirect(t_tree **tree, int *fd);
+char	**create_path_table(t_envp *envp);
+char	*find_path(char **path_envp, char **cmd);
 
 // Lexer functions
 void	debug_lexer(t_token *list);

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -48,16 +48,16 @@ void	split_free(char **split);
 t_envp	*create_envp_table(char **envp);
 
 //Execution
-int execution(t_tree *tree, t_envp *envp, int *fd);
+int execution(t_tree *tree, t_envp *envp);
 int	redirect(t_tree **tree, int *fd);
-<<<<<<< HEAD
 
 // Lexer functions
 void	debug_lexer(t_token *list);
 char	***lexer(char *input, t_tokens_type **signals_ptr, t_check *flags);
 void	ft_skip_spaces(char *input, int *index);
 int		ft_isspace(char c);
-=======
->>>>>>> a76e4aea5fd1080f9663ce9d49c28cc9e40b9b33
+
+// Parser functions
+t_tree	*parser(char *input);
 
 #endif

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -56,16 +56,16 @@ static char	*find_path(char **path_envp, char **cmd)
 
 static int	child_process(t_tree *tree, char **envp, int fd[2], char **path)
 {
-    char    *full_path;
-    char    **node;
+	char	*full_path;
+	char	**node;
 
-    if (tree->signal != CMD)
-    {
-        if (redirect(&tree, fd))
-          		return (1);
-    }
-    node = (char **)tree->node;
-   	full_path = find_path(path, node);
+	if (tree->signal != CMD)
+	{
+		if (redirect(&tree, fd))
+			return (1);
+	}
+	node = (char **)tree->node;
+	full_path = find_path(path, node);
 	execve(full_path, node, envp);
 	free(full_path);
 	envp_char_free(&envp);
@@ -77,15 +77,15 @@ static int	base_exec(char **path_table, t_tree *tree, char **envp)
 {
 	int		err;
 	pid_t	pid;
-	int     fd[2];
+	int		fd[2];
 
 	//if (builtin)
 		//Run builtin
 		// Return status code
 	err = 0;
 	if (tree->signal != CMD)
-	    if (pipe(fd) == -1)
-    		return (1);
+		if (pipe(fd) == -1)
+			return (1);
 	pid = fork();
 	if (pid == 0)
 		err = child_process(tree, envp, fd, path_table);
@@ -96,14 +96,6 @@ static int	base_exec(char **path_table, t_tree *tree, char **envp)
 	}
 	waitpid(pid, &err, 0);
 	return (err);
-}
-
-int exec_pipe(t_tree *tree, char **path_table, char **envp)
-{
-	int		status_code;
-
-	status_code = base_exec(path_table, tree, envp);
-	return (status_code);
 }
 
 int execution(t_tree *tree, t_envp *envp_table)
@@ -122,10 +114,7 @@ int execution(t_tree *tree, t_envp *envp_table)
 		split_free(path_table);
 		return (1);
 	}
-	if (tree->signal == CMD)
-		status_code = base_exec(path_table, tree, rebuilt_envp);
-	else
-		status_code = exec_pipe(tree, path_table, rebuilt_envp);
+	status_code = base_exec(path_table, tree, rebuilt_envp);
 	split_free(rebuilt_envp);
 	split_free(path_table);
 	return (status_code);

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -43,9 +43,9 @@ static char	*find_path(char **path_envp, char **cmd)
 	return (NULL);
 }
 
+
 static int	child_process(char **envp, char **cmd, char *path)
 {
-	close(0);
 	execve(path, cmd, envp);
 	free(path);
 	// free cmd
@@ -54,7 +54,7 @@ static int	child_process(char **envp, char **cmd, char *path)
 	exit(127);
 }
 
-static int	base_exec(char **envp, t_tree *tree)
+static int	base_exec(char **envp, t_tree *tree, int *fd)
 {
 	char	*path;
 	pid_t	pid;
@@ -73,6 +73,13 @@ static int	base_exec(char **envp, t_tree *tree)
 	pid = fork();
 	if (pid == 0)
 	{
+		if (redirect(tree, fd))
+		{
+			free(path);
+			return (1);
+		}
+		close(fd[0]);
+		close(fd[1]);
 		err = child_process(envp, node, path);
 	}
 	waitpid(pid, &err, 0);
@@ -80,7 +87,7 @@ static int	base_exec(char **envp, t_tree *tree)
 	return (err);
 }
 
-int execution(t_tree *tree, t_envp *envp)
+int execution(t_tree *tree, t_envp *envp, int *fd)
 {
 	char	**path_table;
 	int		status_error;
@@ -88,9 +95,14 @@ int execution(t_tree *tree, t_envp *envp)
 	path_table = create_path_table(envp);
 	if (!path_table)
 		return (1);
+	if (pipe(fd) == -1)
+	{
+		envp_char_free(&path_table);
+		return (1);
+	}
 	if (tree->signal == CMD)
 	{
-		status_error = base_exec(path_table, tree);
+		status_error = base_exec(path_table, tree, fd);
 		envp_char_free(&path_table);
 		return (status_error); // Temp to make the function compile
 	}

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -1,59 +1,5 @@
 #include "../../includes/minishell.h"
 
-static char	**create_path_table(t_envp *envp)
-{
-	char	**table;
-
-	table = NULL;
-	while(envp != NULL)
-	{
-		if (ft_strncmp(envp->key, "PATH", 4) == 0)
-		{
-			table = ft_split(envp->value, ':');
-			break;
-		}
-		envp = envp->next;
-	}
-	return (table);
-}
-
-static char	*find_fullpath(char *path, char **path_envp)
-{
-	int		index;
-	char	*full_path;
-
-	index = 0;
-	full_path = NULL;
-	while(path_envp[index] != NULL)
-	{
-		full_path = ft_strjoin(path_envp[index], path);
-		if (!full_path)
-			return (NULL);
-		if (access(full_path, F_OK | X_OK) == 0)
-			break;
-		free(full_path);
-		full_path = NULL;
-		index++;
-	}
-	return (full_path);
-}
-
-static char	*find_path(char **path_envp, char **cmd)
-{
-	char	*path;
-	char	*full_path;
-
-	path = ft_strjoin("/", cmd[0]);
-	if (!path)
-		return (NULL);
-	if (access(path, X_OK | F_OK) == 0)
-		return (path);
-	full_path = find_fullpath(path, path_envp);
-	free(path);
-	return (full_path);
-}
-
-
 static int	child_process(t_tree *tree, char **envp, int fd[2], char **path)
 {
 	char	*full_path;
@@ -98,7 +44,7 @@ static int	base_exec(char **path_table, t_tree *tree, char **envp)
 	return (err);
 }
 
-int execution(t_tree *tree, t_envp *envp_table)
+int	execution(t_tree *tree, t_envp *envp_table)
 {
 	char	**path_table;
 	int		status_code;

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -54,10 +54,9 @@ static int	child_process(char **envp, char **cmd, char *path)
 	exit(127);
 }
 
-static int	base_exec(char **envp, t_tree *tree, int *fd)
+static int	base_exec(char **envp, t_tree *tree)
 {
 	char	*path;
-	pid_t	pid;
 	int		err;
 	char	**node;
 
@@ -66,43 +65,44 @@ static int	base_exec(char **envp, t_tree *tree, int *fd)
 		// Return status code
 	err = 0;
 	path = NULL;
-	pid = fork();
-	if (pid == 0)
-	{
-		if (redirect(&tree, fd))
-		{
-			free(path);
-			return (1);
-		}
-		node = (char **)tree->node;
-		path = find_path(envp, node);
-		if (!path)
-			return (1);
-		close(fd[0]);
-		close(fd[1]);
-		err = child_process(envp, node, path);
-	}
-	waitpid(pid, &err, 0);
+	node = (char **)tree->node;
+	path = find_path(envp, node);
+	if (!path)
+		return (1);
+	err = child_process(envp, node, path);
 	free(path);
 	return (err);
 }
 
-int execution(t_tree *tree, t_envp *envp, int *fd)
+int execution(t_tree *tree, t_envp *envp)
 {
 	char	**path_table;
 	int		status_code;
+	pid_t	pid;
+	int		fd[2];
 
-	//Initialize status code as ok
 	status_code = 0;
 	path_table = create_path_table(envp);
 	if (!path_table)
 		return (1);
-	if (pipe(fd) == -1)
+	if (tree->signal != CMD && pipe(fd) == -1)
 	{
 		envp_char_free(&path_table);
 		return (1);
 	}
-	status_code = base_exec(path_table, tree, fd);
+	pid = fork();
+	if (pid == 0)
+	{
+		if (tree->signal != CMD && redirect(&tree, fd))
+			return (1);
+		status_code = base_exec(path_table, tree);
+	}
+	if (tree->signal != CMD)
+	{
+		close(fd[0]);
+		close(fd[1]);
+	}
+	waitpid(pid, &status_code, 0);
 	envp_char_free(&path_table);
 	return (status_code); // Temp to make the function compile
 	//TODO: Criar o export e adicionar o status_code dentro da variavel $?

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -17,10 +17,30 @@ static char	**create_path_table(t_envp *envp)
 	return (table);
 }
 
+static char	*find_fullpath(char *path, char **path_envp)
+{
+	int		index;
+	char	*full_path;
+
+	index = 0;
+	full_path = NULL;
+	while(path_envp[index] != NULL)
+	{
+		full_path = ft_strjoin(path_envp[index], path);
+		if (!full_path)
+			return (NULL);
+		if (access(full_path, F_OK | X_OK) == 0)
+			break;
+		free(full_path);
+		full_path = NULL;
+		index++;
+	}
+	return (full_path);
+}
+
 static char	*find_path(char **path_envp, char **cmd)
 {
 	char	*path;
-	int		index;
 	char	*full_path;
 
 	path = ft_strjoin("/", cmd[0]);
@@ -28,19 +48,9 @@ static char	*find_path(char **path_envp, char **cmd)
 		return (NULL);
 	if (access(path, X_OK | F_OK) == 0)
 		return (path);
-	index = 0;
-	while(path_envp[index] != NULL)
-	{
-		full_path = ft_strjoin(path_envp[index], path);
-		if (!full_path)
-			return (NULL);
-		if (access(full_path, F_OK | X_OK) == 0)
-			return (full_path);
-		free(full_path);
-		full_path = NULL;
-		index++;
-	}
-	return (NULL);
+	full_path = find_fullpath(path, path_envp);
+	free(path);
+	return (full_path);
 }
 
 
@@ -58,6 +68,7 @@ static int	base_exec(char **path_table, t_tree *tree, char **envp)
 	char	*path;
 	int		err;
 	char	**node;
+	pid_t	pid;
 
 	//if (builtin)
 		//Run builtin
@@ -65,37 +76,37 @@ static int	base_exec(char **path_table, t_tree *tree, char **envp)
 	err = 0;
 	path = NULL;
 	node = (char **)tree->node;
+
 	path = find_path(path_table, node);
 	if (!path)
 		return (1);
-	err = child_process(node, path, envp);
+	pid = fork();
+	if (pid == 0)
+	{
+		err = child_process(node, path, envp);
+	}
 	free(path);
+	waitpid(pid, &err, 0);
 	return (err);
 }
 
 int exec_pipe(t_tree *tree, char **path_table, int fd[2], char **envp)
 {
 	int		status_code;
-	pid_t	pid;
 
 	if (tree->signal == PIPE && pipe(fd) == -1)
 	{
 		envp_char_free(&path_table);
 		return (1);
 	}
-	pid = fork();
-	if (pid == 0)
-	{
-		if (tree->signal != CMD && redirect(&tree, fd) == 0)
-			return (1);
-		status_code = base_exec(path_table, tree, envp);
-	}
+	if (tree->signal != CMD && redirect(&tree, fd) == 0)
+		return (1);
+	status_code = base_exec(path_table, tree, envp);
 	if (tree->signal != CMD)
 	{
 		close(fd[0]);
 		close(fd[1]);
 	}
-	waitpid(pid, &status_code, 0);
 	return (status_code);
 }
 
@@ -116,13 +127,17 @@ int execution(t_tree *tree, t_envp *envp_table)
 		split_free(path_table);
 		return (1);
 	}
+	if (tree->signal >= INPUT && tree->signal <= HEREDOC)
+		if (redirect(&tree, fd))
+		{
+			split_free(path_table);
+			return (1);
+		}
 	if (tree->signal == CMD)
-	{
-        status_code = base_exec(path_table, tree, rebuilt_envp);
-    	return (status_code);
-	}
-	else if (tree->signal == PIPE)
+		status_code = base_exec(path_table, tree, rebuilt_envp);
+	else
 		status_code = exec_pipe(tree, path_table, fd, rebuilt_envp);
+	split_free(rebuilt_envp);
 	split_free(path_table);
 	return (status_code); // Temp to make the function compile
 	//TODO: Criar o export e adicionar o status_code dentro da variavel $?

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -44,17 +44,16 @@ static char	*find_path(char **path_envp, char **cmd)
 }
 
 
-static int	child_process(char **envp, char **cmd, char *path)
+static int	child_process(char **cmd, char *path, char **envp)
 {
 	execve(path, cmd, envp);
 	free(path);
-	// free cmd
 	envp_char_free(&envp);
 	perror("Error");
 	exit(127);
 }
 
-static int	base_exec(char **envp, t_tree *tree)
+static int	base_exec(char **path_table, t_tree *tree, char **envp)
 {
 	char	*path;
 	int		err;
@@ -66,26 +65,20 @@ static int	base_exec(char **envp, t_tree *tree)
 	err = 0;
 	path = NULL;
 	node = (char **)tree->node;
-	path = find_path(envp, node);
+	path = find_path(path_table, node);
 	if (!path)
 		return (1);
-	err = child_process(envp, node, path);
+	err = child_process(node, path, envp);
 	free(path);
 	return (err);
 }
 
-int execution(t_tree *tree, t_envp *envp)
+int exec_pipe(t_tree *tree, char **path_table, int fd[2], char **envp)
 {
-	char	**path_table;
 	int		status_code;
 	pid_t	pid;
-	int		fd[2];
 
-	status_code = 0;
-	path_table = create_path_table(envp);
-	if (!path_table)
-		return (1);
-	if (tree->signal != CMD && pipe(fd) == -1)
+	if (tree->signal == PIPE && pipe(fd) == -1)
 	{
 		envp_char_free(&path_table);
 		return (1);
@@ -93,9 +86,9 @@ int execution(t_tree *tree, t_envp *envp)
 	pid = fork();
 	if (pid == 0)
 	{
-		if (tree->signal != CMD && redirect(&tree, fd))
+		if (tree->signal != CMD && redirect(&tree, fd) == 0)
 			return (1);
-		status_code = base_exec(path_table, tree);
+		status_code = base_exec(path_table, tree, envp);
 	}
 	if (tree->signal != CMD)
 	{
@@ -103,6 +96,33 @@ int execution(t_tree *tree, t_envp *envp)
 		close(fd[1]);
 	}
 	waitpid(pid, &status_code, 0);
+	return (status_code);
+}
+
+int execution(t_tree *tree, t_envp *envp_table)
+{
+	char	**path_table;
+	int		status_code;
+	int		fd[2];
+	char	**rebuilt_envp;
+
+	status_code = 0;
+	path_table = create_path_table(envp_table);
+	if (!path_table)
+		return (1);
+	rebuilt_envp = envp_rebuilt(envp_table);
+	if (!rebuilt_envp)
+	{
+		split_free(path_table);
+		return (1);
+	}
+	if (tree->signal == CMD)
+	{
+        status_code = base_exec(path_table, tree, rebuilt_envp);
+    	return (status_code);
+	}
+	else if (tree->signal == PIPE)
+		status_code = exec_pipe(tree, path_table, fd, rebuilt_envp);
 	split_free(path_table);
 	return (status_code); // Temp to make the function compile
 	//TODO: Criar o export e adicionar o status_code dentro da variavel $?

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -23,7 +23,7 @@ static char	*find_path(char **path_envp, char **cmd)
 	int		index;
 	char	*full_path;
 
-	path = cmd[0];
+	path = ft_strjoin("/", cmd[0]);
 	if (!path)
 		return (NULL);
 	if (access(path, X_OK | F_OK) == 0)
@@ -66,18 +66,18 @@ static int	base_exec(char **envp, t_tree *tree, int *fd)
 		// Return status code
 	err = 0;
 	path = NULL;
-	node = (char **)tree->node;
-	path = find_path(envp, node);
-	if (!path)
-		return (1);
 	pid = fork();
 	if (pid == 0)
 	{
-		if (redirect(tree, fd))
+		if (redirect(&tree, fd))
 		{
 			free(path);
 			return (1);
 		}
+		node = (char **)tree->node;
+		path = find_path(envp, node);
+		if (!path)
+			return (1);
 		close(fd[0]);
 		close(fd[1]);
 		err = child_process(envp, node, path);
@@ -90,8 +90,10 @@ static int	base_exec(char **envp, t_tree *tree, int *fd)
 int execution(t_tree *tree, t_envp *envp, int *fd)
 {
 	char	**path_table;
-	int		status_error;
+	int		status_code;
 
+	//Initialize status code as ok
+	status_code = 0;
 	path_table = create_path_table(envp);
 	if (!path_table)
 		return (1);
@@ -100,12 +102,8 @@ int execution(t_tree *tree, t_envp *envp, int *fd)
 		envp_char_free(&path_table);
 		return (1);
 	}
-	if (tree->signal == CMD)
-	{
-		status_error = base_exec(path_table, tree, fd);
-		envp_char_free(&path_table);
-		return (status_error); // Temp to make the function compile
-	}
-	//TODO: Criar o export e adicionar o status_error dentro da variavel $?
-	return (0);
+	status_code = base_exec(path_table, tree, fd);
+	envp_char_free(&path_table);
+	return (status_code); // Temp to make the function compile
+	//TODO: Criar o export e adicionar o status_code dentro da variavel $?
 }

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -1,5 +1,4 @@
 #include "../../includes/minishell.h"
-#include <readline/readline.h>
 
 static char	**create_path_table(t_envp *envp)
 {
@@ -55,39 +54,41 @@ static char	*find_path(char **path_envp, char **cmd)
 }
 
 
-static int	child_process(char **cmd, char *path, char **envp)
+static int	child_process(t_tree *tree, char **envp, int fd[2], char **path)
 {
-	execve(path, cmd, envp);
-	free(path);
+    char    *full_path;
+    char    **node;
+
+    if (tree->signal != CMD)
+    {
+        if (redirect(&tree, fd))
+          		return (1);
+    }
+    node = (char **)tree->node;
+   	full_path = find_path(path, node);
+	execve(full_path, node, envp);
+	free(full_path);
 	envp_char_free(&envp);
 	perror("Error");
 	exit(127);
 }
 
-static int	base_exec(char **path_table, t_tree *tree, char **envp, int fd[2])
+static int	base_exec(char **path_table, t_tree *tree, char **envp)
 {
-	char	*path;
 	int		err;
-	char	**node;
 	pid_t	pid;
+	int     fd[2];
 
 	//if (builtin)
 		//Run builtin
 		// Return status code
 	err = 0;
-	path = NULL;
-	node = (char **)tree->node;
-	path = find_path(path_table, node);
-	if (!path)
-		return (1);
+	if (tree->signal != CMD)
+	    if (pipe(fd) == -1)
+    		return (1);
 	pid = fork();
 	if (pid == 0)
-	{
-    	if (tree->signal != CMD && redirect(&tree, fd) == 0)
-    		return (1);
-		err = child_process(node, path, envp);
-	}
-	free(path);
+		err = child_process(tree, envp, fd, path_table);
 	if (tree->signal != CMD)
 	{
 		close(fd[0]);
@@ -97,16 +98,11 @@ static int	base_exec(char **path_table, t_tree *tree, char **envp, int fd[2])
 	return (err);
 }
 
-int exec_pipe(t_tree *tree, char **path_table, char **envp, int fd[2])
+int exec_pipe(t_tree *tree, char **path_table, char **envp)
 {
 	int		status_code;
 
-	if (tree->signal == PIPE && pipe(fd) == -1)
-	{
-		envp_char_free(&path_table);
-		return (1);
-	}
-	status_code = base_exec(path_table, tree, envp, fd);
+	status_code = base_exec(path_table, tree, envp);
 	return (status_code);
 }
 
@@ -114,7 +110,6 @@ int execution(t_tree *tree, t_envp *envp_table)
 {
 	char	**path_table;
 	int		status_code;
-	int		fd[2];
 	char	**rebuilt_envp;
 
 	status_code = 0;
@@ -128,11 +123,11 @@ int execution(t_tree *tree, t_envp *envp_table)
 		return (1);
 	}
 	if (tree->signal == CMD)
-		status_code = base_exec(path_table, tree, rebuilt_envp, fd);
+		status_code = base_exec(path_table, tree, rebuilt_envp);
 	else
-		status_code = exec_pipe(tree, path_table, rebuilt_envp, fd);
+		status_code = exec_pipe(tree, path_table, rebuilt_envp);
 	split_free(rebuilt_envp);
 	split_free(path_table);
-	return (status_code); // Temp to make the function compile
+	return (status_code);
 	//TODO: Criar o export e adicionar o status_code dentro da variavel $?
 }

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -103,7 +103,7 @@ int execution(t_tree *tree, t_envp *envp)
 		close(fd[1]);
 	}
 	waitpid(pid, &status_code, 0);
-	envp_char_free(&path_table);
+	split_free(path_table);
 	return (status_code); // Temp to make the function compile
 	//TODO: Criar o export e adicionar o status_code dentro da variavel $?
 }

--- a/src/executor/execution_base.c
+++ b/src/executor/execution_base.c
@@ -1,4 +1,5 @@
 #include "../../includes/minishell.h"
+#include <readline/readline.h>
 
 static char	**create_path_table(t_envp *envp)
 {
@@ -63,7 +64,7 @@ static int	child_process(char **cmd, char *path, char **envp)
 	exit(127);
 }
 
-static int	base_exec(char **path_table, t_tree *tree, char **envp)
+static int	base_exec(char **path_table, t_tree *tree, char **envp, int fd[2])
 {
 	char	*path;
 	int		err;
@@ -76,21 +77,27 @@ static int	base_exec(char **path_table, t_tree *tree, char **envp)
 	err = 0;
 	path = NULL;
 	node = (char **)tree->node;
-
 	path = find_path(path_table, node);
 	if (!path)
 		return (1);
 	pid = fork();
 	if (pid == 0)
 	{
+    	if (tree->signal != CMD && redirect(&tree, fd) == 0)
+    		return (1);
 		err = child_process(node, path, envp);
 	}
 	free(path);
+	if (tree->signal != CMD)
+	{
+		close(fd[0]);
+		close(fd[1]);
+	}
 	waitpid(pid, &err, 0);
 	return (err);
 }
 
-int exec_pipe(t_tree *tree, char **path_table, int fd[2], char **envp)
+int exec_pipe(t_tree *tree, char **path_table, char **envp, int fd[2])
 {
 	int		status_code;
 
@@ -99,14 +106,7 @@ int exec_pipe(t_tree *tree, char **path_table, int fd[2], char **envp)
 		envp_char_free(&path_table);
 		return (1);
 	}
-	if (tree->signal != CMD && redirect(&tree, fd) == 0)
-		return (1);
-	status_code = base_exec(path_table, tree, envp);
-	if (tree->signal != CMD)
-	{
-		close(fd[0]);
-		close(fd[1]);
-	}
+	status_code = base_exec(path_table, tree, envp, fd);
 	return (status_code);
 }
 
@@ -127,16 +127,10 @@ int execution(t_tree *tree, t_envp *envp_table)
 		split_free(path_table);
 		return (1);
 	}
-	if (tree->signal >= INPUT && tree->signal <= HEREDOC)
-		if (redirect(&tree, fd))
-		{
-			split_free(path_table);
-			return (1);
-		}
 	if (tree->signal == CMD)
-		status_code = base_exec(path_table, tree, rebuilt_envp);
+		status_code = base_exec(path_table, tree, rebuilt_envp, fd);
 	else
-		status_code = exec_pipe(tree, path_table, fd, rebuilt_envp);
+		status_code = exec_pipe(tree, path_table, rebuilt_envp, fd);
 	split_free(rebuilt_envp);
 	split_free(path_table);
 	return (status_code); // Temp to make the function compile

--- a/src/executor/execution_redir.c
+++ b/src/executor/execution_redir.c
@@ -1,5 +1,18 @@
 #include "../../includes/minishell.h"
 
+int	base_redir(t_tree *tree, int *fd)
+{
+	if (!tree)
+		return(1);
+	if (dup2(fd[0], STDIN_FILENO) == -1)
+		return (1);
+	if (dup2(fd[1], STDOUT_FILENO) == -1)
+		return (1);
+	close(fd[0]);
+	close(fd[1]);
+	return (0);
+}
+
 static int	define_stdin(t_tree *tree, int *fd, int permission)
 {
 	int	in_fd;
@@ -8,13 +21,15 @@ static int	define_stdin(t_tree *tree, int *fd, int permission)
 		return (1);
 	if (tree->signal == INPUT || tree->signal == HEREDOC)
 	{
-		in_fd = open(tree->left->node, permission);
+		in_fd = open(((char **)tree->left->node)[0], permission);
 		if (in_fd == -1)
 			return (1);
 		if (dup2(fd[0], STDIN_FILENO) == -1)
 			return (1);
 		close(in_fd);
 	}
+	else
+		base_redir(tree, fd);
 	return (0);
 }
 
@@ -26,13 +41,15 @@ static int	define_stdout(t_tree *tree, int *fd, int permission)
 		return (1);
 	if (tree->signal == OUTPUT || tree->signal == APPEND)
 	{
-		out_fd = open(tree->left->node, permission, 0644);
+		out_fd = open(((char **)tree->left->node)[0], permission, 0644);
 		if (out_fd == -1)
 			return (1);
 		if (dup2(fd[1], STDOUT_FILENO) == -1)
 			return (1);
 		close(out_fd);
 	}
+	else
+		base_redir(tree, fd);
 	return (0);
 }
 
@@ -51,29 +68,22 @@ static int	check_permission(t_tree *tree)
 	return (permission);
 }
 
-int	redirect(t_tree *tree, int *fd)
+int	redirect(t_tree **tree, int *fd)
 {
 	int	permission;
 
-	if (!tree)
+	if (!*tree)
 		return (1);
-	if (tree->signal < INPUT || tree->signal > HEREDOC)
+	if ((*tree)->signal >= INPUT && (*tree)->signal <= HEREDOC)
 	{
-		if (dup2(fd[0], STDIN_FILENO) == -1)
+		permission = check_permission(*tree);
+		if (define_stdin((*tree), fd, permission))
 			return (1);
-		if (dup2(fd[1], STDOUT_FILENO) == -1)
+		if (define_stdout((*tree), fd, permission))
 			return (1);
-		close(fd[0]);
-		close(fd[1]);
+		*tree = (*tree)->right;
 	}
 	else
-	{
-		permission = check_permission(tree);
-		if (define_stdin(tree, fd, permission))
-			return (1);
-		if (define_stdout(tree, fd, permission))
-			return (1);
-		tree = tree->right;
-	}
+		base_redir(*tree, fd);
 	return (0);
 }

--- a/src/executor/execution_redir.c
+++ b/src/executor/execution_redir.c
@@ -1,18 +1,4 @@
 #include "../../includes/minishell.h"
-#include <unistd.h>
-
-int	base_redir(t_tree *tree, int *fd)
-{
-	if (!tree)
-		return(1);
-	if (dup2(fd[0], STDIN_FILENO) == -1)
-		return (1);
-	if (dup2(fd[1], STDOUT_FILENO) == -1)
-		return (1);
-	close(fd[0]);
-	close(fd[1]);
-	return (0);
-}
 
 static int	define_stdin(t_tree *tree, int *fd, int permission)
 {
@@ -30,7 +16,10 @@ static int	define_stdin(t_tree *tree, int *fd, int permission)
 		close(in_fd);
 	}
 	else if (tree->signal == PIPE)
-		base_redir(tree, fd);
+	{
+		if (dup2(fd[0], STDIN_FILENO) == -1)
+			return (1);
+	}
 	return (0);
 }
 
@@ -50,7 +39,10 @@ static int	define_stdout(t_tree *tree, int *fd, int permission)
 		close(out_fd);
 	}
 	else if (tree->signal == PIPE)
-		base_redir(tree, fd);
+	{
+		if (dup2(fd[1], STDOUT_FILENO) == -1)
+			return (1);
+	}
 	return (0);
 }
 
@@ -61,11 +53,11 @@ static int	check_permission(t_tree *tree)
 	if (!tree)
 		return (-1);
 	if (tree->signal == OUTPUT)
-		permission = O_WRONLY | O_CREAT;
+		permission = O_WRONLY | O_CREAT | O_TRUNC;
 	else if (tree->signal == INPUT || tree->signal == HEREDOC)
 		permission = O_RDONLY;
 	else
-		permission = O_WRONLY | O_APPEND;
+		permission = O_WRONLY | O_APPEND | O_CREAT;
 	return (permission);
 }
 

--- a/src/executor/execution_redir.c
+++ b/src/executor/execution_redir.c
@@ -8,8 +8,6 @@ int	base_redir(t_tree *tree, int *fd)
 		return (1);
 	if (dup2(fd[1], STDOUT_FILENO) == -1)
 		return (1);
-	close(fd[0]);
-	close(fd[1]);
 	return (0);
 }
 
@@ -85,5 +83,7 @@ int	redirect(t_tree **tree, int *fd)
 	}
 	else
 		base_redir(*tree, fd);
+	close(fd[0]);
+	close(fd[1]);
 	return (0);
 }

--- a/src/executor/execution_redir.c
+++ b/src/executor/execution_redir.c
@@ -1,0 +1,79 @@
+#include "../../includes/minishell.h"
+
+static int	define_stdin(t_tree *tree, int *fd, int permission)
+{
+	int	in_fd;
+
+	if (!tree)
+		return (1);
+	if (tree->signal == INPUT || tree->signal == HEREDOC)
+	{
+		in_fd = open(tree->left->node, permission);
+		if (in_fd == -1)
+			return (1);
+		if (dup2(fd[0], STDIN_FILENO) == -1)
+			return (1);
+		close(in_fd);
+	}
+	return (0);
+}
+
+static int	define_stdout(t_tree *tree, int *fd, int permission)
+{
+	int	out_fd;
+
+	if (!tree)
+		return (1);
+	if (tree->signal == OUTPUT || tree->signal == APPEND)
+	{
+		out_fd = open(tree->left->node, permission, 0644);
+		if (out_fd == -1)
+			return (1);
+		if (dup2(fd[1], STDOUT_FILENO) == -1)
+			return (1);
+		close(out_fd);
+	}
+	return (0);
+}
+
+static int	check_permission(t_tree *tree)
+{
+	int	permission;
+
+	if (!tree)
+		return (-1);
+	if (tree->signal == OUTPUT)
+		permission = O_WRONLY;
+	else if (tree->signal == INPUT || tree->signal == HEREDOC)
+		permission = O_RDONLY;
+	else
+		permission = O_WRONLY | O_APPEND;
+	return (permission);
+}
+
+int	redirect(t_tree *tree, int *fd)
+{
+	int	permission;
+
+	if (!tree)
+		return (1);
+	if (tree->signal < INPUT || tree->signal > HEREDOC)
+	{
+		if (dup2(fd[0], STDIN_FILENO) == -1)
+			return (1);
+		if (dup2(fd[1], STDOUT_FILENO) == -1)
+			return (1);
+		close(fd[0]);
+		close(fd[1]);
+	}
+	else
+	{
+		permission = check_permission(tree);
+		if (define_stdin(tree, fd, permission))
+			return (1);
+		if (define_stdout(tree, fd, permission))
+			return (1);
+		tree = tree->right;
+	}
+	return (0);
+}

--- a/src/executor/execution_redir.c
+++ b/src/executor/execution_redir.c
@@ -1,4 +1,5 @@
 #include "../../includes/minishell.h"
+#include <unistd.h>
 
 int	base_redir(t_tree *tree, int *fd)
 {
@@ -81,6 +82,8 @@ int	redirect(t_tree **tree, int *fd)
 		return (1);
 	if (define_stdout((*tree), fd, permission))
 		return (1);
+	close(fd[0]);
+	close(fd[1]);
 	*tree = (*tree)->right;
 	return (0);
 }

--- a/src/executor/execution_redir.c
+++ b/src/executor/execution_redir.c
@@ -8,6 +8,8 @@ int	base_redir(t_tree *tree, int *fd)
 		return (1);
 	if (dup2(fd[1], STDOUT_FILENO) == -1)
 		return (1);
+	close(fd[0]);
+	close(fd[1]);
 	return (0);
 }
 
@@ -22,11 +24,11 @@ static int	define_stdin(t_tree *tree, int *fd, int permission)
 		in_fd = open(((char **)tree->left->node)[0], permission);
 		if (in_fd == -1)
 			return (1);
-		if (dup2(fd[0], STDIN_FILENO) == -1)
+		if (dup2(in_fd, STDIN_FILENO) == -1)
 			return (1);
 		close(in_fd);
 	}
-	else
+	else if (tree->signal == PIPE)
 		base_redir(tree, fd);
 	return (0);
 }
@@ -42,11 +44,11 @@ static int	define_stdout(t_tree *tree, int *fd, int permission)
 		out_fd = open(((char **)tree->left->node)[0], permission, 0644);
 		if (out_fd == -1)
 			return (1);
-		if (dup2(fd[1], STDOUT_FILENO) == -1)
+		if (dup2(out_fd, STDOUT_FILENO) == -1)
 			return (1);
 		close(out_fd);
 	}
-	else
+	else if (tree->signal == PIPE)
 		base_redir(tree, fd);
 	return (0);
 }
@@ -58,7 +60,7 @@ static int	check_permission(t_tree *tree)
 	if (!tree)
 		return (-1);
 	if (tree->signal == OUTPUT)
-		permission = O_WRONLY;
+		permission = O_WRONLY | O_CREAT;
 	else if (tree->signal == INPUT || tree->signal == HEREDOC)
 		permission = O_RDONLY;
 	else
@@ -72,18 +74,13 @@ int	redirect(t_tree **tree, int *fd)
 
 	if (!*tree)
 		return (1);
-	if ((*tree)->signal >= INPUT && (*tree)->signal <= HEREDOC)
-	{
-		permission = check_permission(*tree);
-		if (define_stdin((*tree), fd, permission))
-			return (1);
-		if (define_stdout((*tree), fd, permission))
-			return (1);
-		*tree = (*tree)->right;
-	}
-	else
-		base_redir(*tree, fd);
-	close(fd[0]);
-	close(fd[1]);
+	if ((*tree)->signal < INPUT || (*tree)->signal > PIPE)
+		return (1);
+	permission = check_permission(*tree);
+	if (define_stdin((*tree), fd, permission))
+		return (1);
+	if (define_stdout((*tree), fd, permission))
+		return (1);
+	*tree = (*tree)->right;
 	return (0);
 }

--- a/src/executor/execution_utils.c
+++ b/src/executor/execution_utils.c
@@ -1,0 +1,54 @@
+# include "../../includes/minishell.h"
+
+char	**create_path_table(t_envp *envp)
+{
+	char	**table;
+
+	table = NULL;
+	while (envp != NULL)
+	{
+		if (ft_strncmp(envp->key, "PATH", 4) == 0)
+		{
+			table = ft_split(envp->value, ':');
+			break ;
+		}
+		envp = envp->next;
+	}
+	return (table);
+}
+
+static char	*find_fullpath(char *path, char **path_envp)
+{
+	int		index;
+	char	*full_path;
+
+	index = 0;
+	full_path = NULL;
+	while(path_envp[index] != NULL)
+	{
+		full_path = ft_strjoin(path_envp[index], path);
+		if (!full_path)
+			return (NULL);
+		if (access(full_path, F_OK | X_OK) == 0)
+			break ;
+		free(full_path);
+		full_path = NULL;
+		index++;
+	}
+	return (full_path);
+}
+
+char	*find_path(char **path_envp, char **cmd)
+{
+	char	*path;
+	char	*full_path;
+
+	path = ft_strjoin("/", cmd[0]);
+	if (!path)
+		return (NULL);
+	if (access(path, X_OK | F_OK) == 0)
+		return (path);
+	full_path = find_fullpath(path, path_envp);
+	free(path);
+	return (full_path);
+}

--- a/src/free/envp_free.c
+++ b/src/free/envp_free.c
@@ -45,8 +45,9 @@ void	envp_char_free(char ***envp)
 	while((*envp)[index])
 	{
 		split_free(&(*envp)[index]);
+		(*envp)[index] = NULL;
 		index++;
 	}
-	free(*envp);
+	free(envp);
 	envp = NULL;
 }

--- a/src/free/envp_free.c
+++ b/src/free/envp_free.c
@@ -42,12 +42,12 @@ void	envp_char_free(char ***envp)
 	if (!envp || !*envp)
 		return ;
 	index = 0;
-	while(envp[index])
+	while ((*envp)[index])
 	{
-		split_free(envp[index]);
-		envp[index] = NULL;
+		split_free(&(*envp)[index]);
+		(*envp)[index] = NULL;
 		index++;
 	}
-	free(envp);
-	envp = NULL;
+	free(*envp);
+	*envp = NULL;
 }

--- a/src/free/envp_free.c
+++ b/src/free/envp_free.c
@@ -42,10 +42,10 @@ void	envp_char_free(char ***envp)
 	if (!envp || !*envp)
 		return ;
 	index = 0;
-	while((*envp)[index])
+	while(envp[index])
 	{
-		split_free(&(*envp)[index]);
-		(*envp)[index] = NULL;
+		split_free(envp[index]);
+		envp[index] = NULL;
 		index++;
 	}
 	free(envp);

--- a/src/free/envp_free.c
+++ b/src/free/envp_free.c
@@ -1,5 +1,4 @@
 #include "../../includes/minishell.h"
-#include <stddef.h>
 
 void	envp_free(t_envp **envp)
 {
@@ -20,22 +19,6 @@ void	envp_free(t_envp **envp)
 	*envp = NULL;
 }
 
-void	envp_char_free(char ***envp)
-{
-	size_t	index;
-
-	if (!envp || !*envp)
-		return ;
-	index = 0;
-	while((*envp)[index])
-	{
-		free((*envp)[index]);
-		index++;
-	}
-	free(*envp);
-	envp = NULL;
-}
-
 void	split_free(char **split)
 {
 	size_t	index;
@@ -50,4 +33,20 @@ void	split_free(char **split)
 	}
 	free(split);
 	split = NULL;
+}
+
+void	envp_char_free(char ***envp)
+{
+	size_t	index;
+
+	if (!envp || !*envp)
+		return ;
+	index = 0;
+	while((*envp)[index])
+	{
+		split_free(&(*envp)[index]);
+		index++;
+	}
+	free(*envp);
+	envp = NULL;
 }

--- a/src/free/token_list_free.c
+++ b/src/free/token_list_free.c
@@ -3,17 +3,14 @@
 void	token_list_free(t_token *head)
 {
 	t_token	*next;
-	char	**temp;
 
 	while (head)
 	{
 		next = head->next;
 		if (head->token)
 		{
-			temp = (char **)head->token;
-			if (temp[0])
-				free(temp[0]);
-			free(temp);
+			split_free((char **)head->token);
+			free(head->token);
 		}
 		free(head);
 		head = next;

--- a/src/free/tree_free.c
+++ b/src/free/tree_free.c
@@ -1,11 +1,27 @@
 #include "../../includes/minishell.h"
 
+void	tree_node_free(char **node)
+{
+	int	index;
+
+	if (!node)
+		return;
+	index = 0;
+	while (node[index] != NULL)
+	{
+		free(node[index]);
+		index++;
+	}
+	node = NULL;
+}
+
 void	tree_free(t_tree *tree)
 {
 	if (!tree)
 		return ;
 	tree_free(tree->left);
-	free(tree->node);
+	if (tree->node)
+		tree_node_free((char **)tree->node);
 	tree_free(tree->right);
 	free(tree);
 }

--- a/src/free/tree_free.c
+++ b/src/free/tree_free.c
@@ -1,11 +1,27 @@
 #include "../../includes/minishell.h"
 
+void	tree_node_free(char **node)
+{
+	int	index;
+
+	if (!node)
+		return;
+	index = 0;
+	while (node[index] != NULL)
+	{
+		free(node[index]);
+		index++;
+	}
+	node = NULL;
+}
+
 void	tree_free(t_tree *tree)
 {
 	if (!tree)
 		return ;
 	tree_free(tree->left);
-	free(tree->node);
+	if (tree->node)
+		tree_node_free((char **)tree->node);
 	tree_free(tree->right);
 	if (tree->node)
 	{

--- a/src/free/tree_free.c
+++ b/src/free/tree_free.c
@@ -22,7 +22,7 @@ void	tree_free(t_tree **tree)
 	if ((*tree)->left != NULL)
 		tree_free(&((*tree)->left));
 	if ((*tree)->node)
-		tree_node_free((char **)(*tree)->node);
+		split_free((char **)(*tree)->node);
 	if ((*tree)->right != NULL)
 		tree_free(&((*tree)->right));
 	free(*tree);

--- a/src/free/tree_free.c
+++ b/src/free/tree_free.c
@@ -19,9 +19,13 @@ void	tree_free(t_tree *tree)
 {
 	if (!tree)
 		return ;
-	tree_free(tree->left);
+	if (tree->left)
+		tree_free(tree->left);
+//	if (tree->node)
+//		tree_node_free((char **)tree->node);
 	if (tree->node)
-		tree_node_free((char **)tree->node);
-	tree_free(tree->right);
+		free(tree->node);
+	if (tree->right)
+		tree_free(tree->right);
 	free(tree);
 }

--- a/src/free/tree_free.c
+++ b/src/free/tree_free.c
@@ -19,7 +19,8 @@ void	tree_free(t_tree *tree)
 {
 	if (!tree)
 		return ;
-	tree_free(tree->left);
+	if (tree->left)
+		tree_free(tree->left);
 	if (tree->node)
 		tree_node_free((char **)tree->node);
 	tree_free(tree->right);

--- a/src/free/tree_free.c
+++ b/src/free/tree_free.c
@@ -15,19 +15,16 @@ void	tree_node_free(char **node)
 	node = NULL;
 }
 
-void	tree_free(t_tree *tree)
+void	tree_free(t_tree **tree)
 {
-	if (!tree)
+	if (!tree || !*tree)
 		return ;
-	if (tree->left)
-		tree_free(tree->left);
-	if (tree->node)
-		tree_node_free((char **)tree->node);
-	tree_free(tree->right);
-	if (tree->node)
-	{
-		free(((char **)tree->node)[0]);// libera a string
-		free(tree->node);// libera o char **
-	}
-	free(tree);
+	if ((*tree)->left != NULL)
+		tree_free(&((*tree)->left));
+	if ((*tree)->node)
+		tree_node_free((char **)(*tree)->node);
+	if ((*tree)->right != NULL)
+		tree_free(&((*tree)->right));
+	free(*tree);
+	*tree = NULL;
 }

--- a/src/lexer/lexer.c
+++ b/src/lexer/lexer.c
@@ -1,4 +1,4 @@
-#include "../includes/minishell.h"
+#include "../../includes/minishell.h"
 
 static int	operator_len(t_tokens_type type)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@ int	main(int argc, char **argv, char **envp)
 	t_tree	*tree;
 	t_check	flags;
 	t_envp	*envp_list;
+	int		fd[2];
 
 	if(argc > 1)
 		return (1);
@@ -24,18 +25,23 @@ int	main(int argc, char **argv, char **envp)
 		}
 		//add_history(input);
 		// Hardcode - Lexer vai substituir isso depois
-		char *tokens = ft_strjoin("/", input);
-		t_tokens_type	signal[] = {CMD, EOFILE};
-		char **pointer_token;
+		char **tokens = ft_split(input, ' ');
+		char *cmd = tokens[2];
+		tokens[2] = ft_strjoin("/", cmd);
+		free(cmd);
+		t_tokens_type	signal[] = {INPUT, FILE_PATH, CMD, EOFILE};
+		//char **pointer_token;
 
+//
 		//Create ENVP
 		// TODO: Move envp_list out of the loop.
 		// It's here to test free
 		envp_list = create_envp_table(envp);
 
-		pointer_token = (char **)ft_calloc(2, sizeof(char *));
-		pointer_token[0] = tokens;
-		pointer_token[1] = NULL;
+
+	//	pointer_token = (char **)ft_calloc(2, sizeof(char *));
+	//	pointer_token[0] = tokens;
+	//	pointer_token[1] = NULL;
 
 		flags.word = 1;
 		flags.input = 0;
@@ -43,7 +49,7 @@ int	main(int argc, char **argv, char **envp)
 		flags.pipe = 0;
 		flags.logical = 0;
 
-		head = token_create(&pointer_token, signal);
+		head = token_create(&tokens, signal);
 		if (!head)
 		{
 			ft_printf("Failed to create token list\n");
@@ -56,7 +62,7 @@ int	main(int argc, char **argv, char **envp)
 		//tree_print(tree, 1);
 
 		//Rebuilt ENVP function
-		execution(tree, envp_list);
+		execution(tree, envp_list, fd);
 
 		envp_free(&envp_list);
 		free(tokens);

--- a/src/main.c
+++ b/src/main.c
@@ -7,6 +7,7 @@ int	main(int argc, char **argv, char **envp)
 	t_tree	*tree;
 	t_check	flags;
 	t_envp	*envp_list;
+	int		fd[2];
 
 	if(argc > 1)
 		return (1);
@@ -44,6 +45,15 @@ int	main(int argc, char **argv, char **envp)
 		ft_printf("flags: word=%d input=%d output=%d pipe=%d logical=%d\n",
 			flags.word, flags.input, flags.output, flags.pipe, flags.logical);
 		token_list_free(head);
+
+		tree = tree_create(head, &flags);
+		//ft_printf("You entered: %s\n", input);
+		//tree_print(tree, 1);
+
+		//Rebuilt ENVP function
+		execution(tree, envp_list, fd);
+
+		envp_free(&envp_list);
 		free(tokens);
 		free(signals);
 		free(input);

--- a/src/main.c
+++ b/src/main.c
@@ -1,67 +1,58 @@
 #include "../includes/minishell.h"
 
+static char	*get_input(void)
+{
+	char *input;
+
+	input = readline("minishell$ ");
+	if (!input)
+		return (NULL);
+	if (!*input)
+	{
+	    free(input);
+    	return (NULL);
+	}
+	else
+    	add_history(input);
+	return (input);
+}
+
+static void	execute_input(char *input, t_envp *envp_list)
+{
+	t_tree	*tree;
+
+	tree = parser(input);
+	if (!tree)
+	{
+		perror("Error");
+		free(input);
+		return ;
+	}
+	execution(tree, envp_list);
+	free(input);
+}
+
 int	main(int argc, char **argv, char **envp)
 {
 	char *input;
-//	t_token	*head;
-	t_tree	*tree;
-//	t_check	flags;
 	t_envp	*envp_list;
-//	t_tokens_type	*signals;
-//	char ***tokens;
 
 	if(argc > 1)
 		return (1);
 	(void)*argv;
+	envp_list = create_envp_table(envp);
+	if (!envp_list)
+	{
+		perror("Error");
+		return (1);
+	}
 	while(1)
 	{
-		input = readline("minishell$ ");
+		input = get_input();
 		if (!input)
 			break ;
-		if (!*input)
-		{
-			free(input);
-			continue ;
-		}
-		add_history(input);
-
-//		tokens = lexer(input, &signals, &flags);
-//		if (!tokens)
-//		{
-//			ft_printf("Lexer error: invalid syntax\n");
-//			free(input);
-//			continue ;
-//		}
-//
-//		head = token_create(tokens, signals);
-//		if (!head)
-//		{
-//			ft_printf("Failed to create token list\n");
-//			free(tokens);
-//			free(signals);
-//			free(input);
-//			continue ;
-//		}
-//
-//		tree = tree_create(head, &flags);
-
-		tree = parser(input);
-		if (!tree)
-		{
-			perror("Error");
-			free(input);
-			continue ;
-		}
-		envp_list = create_envp_table(envp);
-
-		//Rebuilt ENVP function
-		execution(tree, envp_list);
-
-//		token_list_free(head);
-		envp_free(&envp_list);
-//		free(tokens);
-//		free(signals);
-//		free(input);
+		execute_input(input, envp_list);
 	}
+	envp_free(&envp_list);
 	return (0);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -9,17 +9,18 @@ static char	*get_input(void)
 		return (NULL);
 	if (!*input)
 	{
-	    free(input);
-    	return (NULL);
+		free(input);
+		return (NULL);
 	}
 	else
-    	add_history(input);
+		add_history(input);
 	return (input);
 }
 
 static void	execute_input(char *input, t_envp *envp_list)
 {
 	t_tree	*tree;
+	int		status_error;
 
 	tree = parser(input);
 	if (!tree)
@@ -28,8 +29,11 @@ static void	execute_input(char *input, t_envp *envp_list)
 		free(input);
 		return ;
 	}
-	execution(tree, envp_list);
+	tree_print(tree, 0);
+	status_error = execution(tree, envp_list);
+	tree_free(&tree);
 	free(input);
+	input = NULL;
 }
 
 int	main(int argc, char **argv, char **envp)

--- a/src/main.c
+++ b/src/main.c
@@ -3,11 +3,12 @@
 int	main(int argc, char **argv, char **envp)
 {
 	char *input;
-	t_token	*head;
+//	t_token	*head;
 	t_tree	*tree;
-	t_check	flags;
+//	t_check	flags;
 	t_envp	*envp_list;
-	int		fd[2];
+//	t_tokens_type	*signals;
+//	char ***tokens;
 
 	if(argc > 1)
 		return (1);
@@ -24,45 +25,43 @@ int	main(int argc, char **argv, char **envp)
 		}
 		add_history(input);
 
-		ft_bzero(&flags, sizeof(t_check));
-		tokens = lexer(input, &signals, &flags);
-		if (!tokens)
+//		tokens = lexer(input, &signals, &flags);
+//		if (!tokens)
+//		{
+//			ft_printf("Lexer error: invalid syntax\n");
+//			free(input);
+//			continue ;
+//		}
+//
+//		head = token_create(tokens, signals);
+//		if (!head)
+//		{
+//			ft_printf("Failed to create token list\n");
+//			free(tokens);
+//			free(signals);
+//			free(input);
+//			continue ;
+//		}
+//
+//		tree = tree_create(head, &flags);
+
+		tree = parser(input);
+		if (!tree)
 		{
-			ft_printf("Lexer error: invalid syntax\n");
+			perror("Error");
 			free(input);
 			continue ;
 		}
-		head = token_create(tokens, signals);
-		if (!head)
-		{
-			ft_printf("Failed to create token list\n");
-			free(tokens);
-			free(signals);
-			free(input);
-			continue ;
-		}
-		debug_lexer(head);
-		ft_printf("flags: word=%d input=%d output=%d pipe=%d logical=%d\n",
-			flags.word, flags.input, flags.output, flags.pipe, flags.logical);
-		token_list_free(head);
-
-		tree = tree_create(head, &flags);
-		tree_print(tree, 0);
-		tree_print_extense(tree);
-		//ft_printf("You entered: %s\n", input);
-		//tree_print(tree, 1);
-
-		char **token_1 = (char **)ft_calloc(2, sizeof(char *));
-		char **token_2 = (char **)ft_calloc(2, sizeof(char *));
-		char **token_3 = (char **)ft_calloc(2, sizeof(char *));
+		envp_list = create_envp_table(envp);
 
 		//Rebuilt ENVP function
-		execution(tree, envp_list, fd);
+		execution(tree, envp_list);
 
+//		token_list_free(head);
 		envp_free(&envp_list);
-		free(tokens);
-		free(signals);
-		free(input);
+//		free(tokens);
+//		free(signals);
+//		free(input);
 	}
 	return (0);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -18,34 +18,34 @@ static int	execute_input(char *input, t_envp *envp_list)
 	return (status_error);
 }
 
-static int  minishell(t_envp *envp)
+static int	minishell(t_envp *envp)
 {
-    char    *input;
-    int     err;
+	char	*input;
+	int		err;
 
-    while(1)
+	while(1)
 	{
-       	input = readline("minishell$ ");
-       	if (!input)
-       		break ;
-       	if (!*input)
-       	{
-       		free(input);
-       		continue ;
-       	}
-       	else
-        {
-      		add_history(input);
-        }
+		input = readline("minishell$ ");
+		if (!input)
+			break ;
+		if (!*input)
+		{
+			free(input);
+			continue ;
+		}
+		else
+		{
+			add_history(input);
+		}
 		err = execute_input(input, envp);
 	}
-    return (err);
+	return (err);
 }
 
 int	main(int argc, char **argv, char **envp)
 {
 	t_envp	*envp_list;
-	int     err;
+	int		err;
 
 	if(argc > 1)
 		return (1);

--- a/src/main.c
+++ b/src/main.c
@@ -18,10 +18,34 @@ static int	execute_input(char *input, t_envp *envp_list)
 	return (status_error);
 }
 
+static int  minishell(t_envp *envp)
+{
+    char    *input;
+    int     err;
+
+    while(1)
+	{
+       	input = readline("minishell$ ");
+       	if (!input)
+       		break ;
+       	if (!*input)
+       	{
+       		free(input);
+       		continue ;
+       	}
+       	else
+        {
+      		add_history(input);
+        }
+		err = execute_input(input, envp);
+	}
+    return (err);
+}
+
 int	main(int argc, char **argv, char **envp)
 {
-	char *input;
 	t_envp	*envp_list;
+	int     err;
 
 	if(argc > 1)
 		return (1);
@@ -32,20 +56,7 @@ int	main(int argc, char **argv, char **envp)
 		perror("Error");
 		return (1);
 	}
-	while(1)
-	{
-    	input = readline("minishell$ ");
-    	if (!input)
-    		break ;
-    	if (!*input)
-    	{
-    		free(input);
-    		continue ;
-    	}
-    	else
-    		add_history(input);
-		execute_input(input, envp_list);
-	}
+	err = minishell(envp_list);
 	envp_free(&envp_list);
-	return (0);
+	return (err);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -26,30 +26,38 @@ int	main(int argc, char **argv, char **envp)
 		//add_history(input);
 		// Hardcode - Lexer vai substituir isso depois
 		char **tokens = ft_split(input, ' ');
-		char *cmd = tokens[2];
-		tokens[2] = ft_strjoin("/", cmd);
+		size_t size = 0;
+		while (tokens[size] != NULL) size++;
+		char *cmd = tokens[size - 1];
+		//tokens[size - 1] = ft_strjoin("/", cmd);
 		free(cmd);
 		t_tokens_type	signal[] = {INPUT, FILE_PATH, CMD, EOFILE};
-		//char **pointer_token;
 
-//
-		//Create ENVP
-		// TODO: Move envp_list out of the loop.
-		// It's here to test free
-		envp_list = create_envp_table(envp);
+		char **token_1 = (char **)ft_calloc(2, sizeof(char *));
+		char **token_2 = (char **)ft_calloc(2, sizeof(char *));
+		char **token_3 = (char **)ft_calloc(2, sizeof(char *));
 
+		token_1[0] = tokens[0];
+		token_1[1] = NULL;
+		token_2[0] = tokens[1];
+		token_2[1] = NULL;
+		token_3[0] = tokens[2];
+		token_3[1] = NULL;
 
-	//	pointer_token = (char **)ft_calloc(2, sizeof(char *));
-	//	pointer_token[0] = tokens;
-	//	pointer_token[1] = NULL;
+		char ***pointer_token;
+		pointer_token = (char ***)ft_calloc(4, sizeof(char **));
+		pointer_token[0] = token_1;
+		pointer_token[1] = token_2;
+		pointer_token[2] = token_3;
+		pointer_token[3] = NULL;
 
 		flags.word = 1;
-		flags.input = 0;
+		flags.input = 1;
 		flags.output = 0;
 		flags.pipe = 0;
 		flags.logical = 0;
 
-		head = token_create(&tokens, signal);
+		head = token_create(pointer_token, signal);
 		if (!head)
 		{
 			ft_printf("Failed to create token list\n");
@@ -58,14 +66,20 @@ int	main(int argc, char **argv, char **envp)
 		}
 
 		tree = tree_create(head, &flags);
+		tree_print(tree, 0);
+		tree_print_extense(tree);
 		//ft_printf("You entered: %s\n", input);
 		//tree_print(tree, 1);
+
+		//Create ENVP
+		// TODO: Move envp_list out of the loop.
+		// It's here to test free
+		envp_list = create_envp_table(envp);
 
 		//Rebuilt ENVP function
 		execution(tree, envp_list, fd);
 
 		envp_free(&envp_list);
-		free(tokens);
 		tree_free(tree);
 		token_no_content_free(head);
 		free(input);

--- a/src/main.c
+++ b/src/main.c
@@ -1,23 +1,6 @@
 #include "../includes/minishell.h"
 
-static char	*get_input(void)
-{
-	char *input;
-
-	input = readline("minishell$ ");
-	if (!input)
-		return (NULL);
-	if (!*input)
-	{
-		free(input);
-		return (NULL);
-	}
-	else
-		add_history(input);
-	return (input);
-}
-
-static void	execute_input(char *input, t_envp *envp_list)
+static int	execute_input(char *input, t_envp *envp_list)
 {
 	t_tree	*tree;
 	int		status_error;
@@ -27,13 +10,12 @@ static void	execute_input(char *input, t_envp *envp_list)
 	{
 		perror("Error");
 		free(input);
-		return ;
+		return (1);
 	}
-	tree_print(tree, 0);
 	status_error = execution(tree, envp_list);
 	tree_free(&tree);
 	free(input);
-	input = NULL;
+	return (status_error);
 }
 
 int	main(int argc, char **argv, char **envp)
@@ -52,9 +34,16 @@ int	main(int argc, char **argv, char **envp)
 	}
 	while(1)
 	{
-		input = get_input();
-		if (!input)
-			break ;
+    	input = readline("minishell$ ");
+    	if (!input)
+    		break ;
+    	if (!*input)
+    	{
+    		free(input);
+    		continue ;
+    	}
+    	else
+    		add_history(input);
 		execute_input(input, envp_list);
 	}
 	envp_free(&envp_list);

--- a/src/main.c
+++ b/src/main.c
@@ -47,8 +47,15 @@ int	main(int argc, char **argv, char **envp)
 		token_list_free(head);
 
 		tree = tree_create(head, &flags);
+		tree_print(tree, 0);
+		tree_print_extense(tree);
 		//ft_printf("You entered: %s\n", input);
 		//tree_print(tree, 1);
+
+		//Create ENVP
+		// TODO: Move envp_list out of the loop.
+		// It's here to test free
+		envp_list = create_envp_table(envp);
 
 		//Rebuilt ENVP function
 		execution(tree, envp_list, fd);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -22,6 +22,7 @@ t_tree	*parser(char *input)
 		return (NULL);
 	}
 	tree = tree_create(head, &flags);
+	token_list_free(head);
 	envp_char_free(tokens);
 	free(signals);
 	return (tree);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -1,0 +1,28 @@
+#include "../../includes/minishell.h"
+
+t_tree	*parser(char *input)
+{
+	char 			***tokens;
+	t_tokens_type	*signals;
+	t_check			flags;
+	t_token			*head;
+	t_tree			*tree;
+
+	tokens = lexer(input, &signals, &flags);
+	if (!tokens)
+	{
+		ft_printf("Lexer error: invalid syntax\n");
+		return (NULL);
+	}
+	head = token_create(tokens, signals);
+	if (!head)
+	{
+		envp_char_free(tokens);
+		free(signals);
+		return (NULL);
+	}
+	tree = tree_create(head, &flags);
+	envp_char_free(tokens);
+	free(signals);
+	return (tree);
+}

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -23,7 +23,7 @@ t_tree	*parser(char *input)
 	}
 	tree = tree_create(head, &flags);
 	token_list_free(head);
-	envp_char_free(tokens);
+	free(tokens);
 	free(signals);
 	return (tree);
 }

--- a/src/token/token_cmd_create.c
+++ b/src/token/token_cmd_create.c
@@ -25,11 +25,7 @@ t_token	*token_create(char ***tokens, t_tokens_type *signal)
 	head = NULL;
 	prev = NULL;
 	index = 0;
-<<<<<<< HEAD
 	while (signal[index] != EOFILE)
-=======
-	while (tokens[index] != NULL)
->>>>>>> 43c784d (fix: correction to datatype char***)
 	{
 		current = token_node(tokens[index], signal[index]);
 		if (!current)

--- a/src/token/token_cmd_create.c
+++ b/src/token/token_cmd_create.c
@@ -25,9 +25,13 @@ t_token	*token_create(char ***tokens, t_tokens_type *signal)
 	head = NULL;
 	prev = NULL;
 	index = 0;
+<<<<<<< HEAD
 	while (signal[index] != EOFILE)
+=======
+	while (tokens[index] != NULL)
+>>>>>>> 43c784d (fix: correction to datatype char***)
 	{
-		current = token_node(&(*tokens)[index], signal[index]);
+		current = token_node(tokens[index], signal[index]);
 		if (!current)
 		{
 			token_list_free(head);
@@ -38,6 +42,7 @@ t_token	*token_create(char ***tokens, t_tokens_type *signal)
 		else
 			prev->next = current;
 		prev = current;
+		tokens[index] = NULL;
 		index++;
 	}
 	return (head);

--- a/src/token/token_cmd_create.c
+++ b/src/token/token_cmd_create.c
@@ -25,9 +25,9 @@ t_token	*token_create(char ***tokens, t_tokens_type *signal)
 	head = NULL;
 	prev = NULL;
 	index = 0;
-	while ((*tokens)[index] != NULL)
+	while (tokens[index] != NULL)
 	{
-		current = token_node(&(*tokens)[index], signal[index]);
+		current = token_node(tokens[index], signal[index]);
 		if (!current)
 		{
 			token_list_free(head);
@@ -38,6 +38,7 @@ t_token	*token_create(char ***tokens, t_tokens_type *signal)
 		else
 			prev->next = current;
 		prev = current;
+		tokens[index] = NULL;
 		index++;
 	}
 	return (head);

--- a/src/tree/tree_build.c
+++ b/src/tree/tree_build.c
@@ -87,8 +87,6 @@ t_tree	*tree_create(t_token *token, t_check *flags)
 
 	if (!token || !flags)
 		return (NULL);
-	// Precedense of logical operators over pipe operator.
-	// Will need to add an if and change the pipe's if to else if
 	tree = NULL;
 	if (flags->pipe)
 		tree = tree_pipe_create(&token);

--- a/src/tree/tree_build.c
+++ b/src/tree/tree_build.c
@@ -105,8 +105,6 @@ t_tree	*tree_create(t_token *token, t_check *flags)
 
 	if (!token || !flags)
 		return (NULL);
-	// Precedense of logical operators over pipe operator.
-	// Will need to add an if and change the pipe's if to else if
 	tree = NULL;
 	if (flags->pipe)
 		tree = tree_pipe_create(&token);

--- a/src/tree/tree_print.c
+++ b/src/tree/tree_print.c
@@ -1,0 +1,19 @@
+#include "../includes/minishell.h"
+
+void	tree_print(t_tree *tree, int level)
+{
+	if (!tree)
+		return ;
+	tree_print(tree->right, level + 1);
+	printf("%*c%s\n", level * 5, ' ', (char *)tree->node);
+	tree_print(tree->left, level + 1);
+}
+
+void	tree_print_extense(t_tree *tree)
+{
+	if (!tree)
+		return ;
+	tree_print_extense(tree->left);
+	ft_printf("%s ", (char *)tree->node);
+	tree_print_extense(tree->right);
+}

--- a/src/tree/tree_print.c
+++ b/src/tree/tree_print.c
@@ -1,11 +1,11 @@
-#include "../includes/minishell.h"
+#include "../../includes/minishell.h"
 
 void	tree_print(t_tree *tree, int level)
 {
 	if (!tree)
 		return ;
 	tree_print(tree->right, level + 1);
-	printf("%*c%s\n", level * 5, ' ', (char *)tree->node);
+	printf("%*c%s\n", level * 5, ' ', ((char **)tree->node)[0]);
 	tree_print(tree->left, level + 1);
 }
 
@@ -14,6 +14,6 @@ void	tree_print_extense(t_tree *tree)
 	if (!tree)
 		return ;
 	tree_print_extense(tree->left);
-	ft_printf("%s ", (char *)tree->node);
+	ft_printf("%s ", ((char **)tree->node)[0]);
 	tree_print_extense(tree->right);
 }

--- a/src/tree/tree_print.c
+++ b/src/tree/tree_print.c
@@ -14,6 +14,6 @@ void	tree_print_extense(t_tree *tree)
 	if (!tree)
 		return ;
 	tree_print_extense(tree->left);
-	ft_printf("%s ", ((char **)tree->node)[0]);
+	ft_printf("%s \n", ((char **)tree->node)[0]);
 	tree_print_extense(tree->right);
 }

--- a/src/tree/tree_print.c
+++ b/src/tree/tree_print.c
@@ -17,3 +17,11 @@ void	tree_print_extense(t_tree *tree)
 	ft_printf("%s \n", ((char **)tree->node)[0]);
 	tree_print_extense(tree->right);
 }
+
+void	tokens_print(t_token *token)
+{
+	if (!token)
+		return ;
+	ft_printf("%s \n", ((char **)token->token)[0]);
+	tokens_print(token->next);
+}

--- a/src/utils/envp_rebuilt.c
+++ b/src/utils/envp_rebuilt.c
@@ -61,5 +61,6 @@ char	**envp_rebuilt(t_envp *head)
 		temp = NULL;
 		index++;
 	}
+	envp[index] = NULL;
 	return (envp);
 }

--- a/src/utils/envp_rebuilt.c
+++ b/src/utils/envp_rebuilt.c
@@ -49,7 +49,7 @@ char	**envp_rebuilt(t_envp *head)
 	if (!envp)
 		return (NULL);
 	index = 0;
-	while (head)
+	while (index < len)
 	{
 		temp = envp_rebuilt_util(head);
 		if (!temp)

--- a/src/utils/envp_rebuilt.c
+++ b/src/utils/envp_rebuilt.c
@@ -61,6 +61,5 @@ char	**envp_rebuilt(t_envp *head)
 		temp = NULL;
 		index++;
 	}
-	envp[index] = NULL;
 	return (envp);
 }


### PR DESCRIPTION
Criado funções para o redir in, redir out com append.
Funciona para comandos simples sem flags.

Main refatorada para separar em funções com menos de 25 linhas.
Execution_base sem leaks de memória e fd. (Apenas fd std estão abertos ao final dos processos -- o que não é leak)

Necessário reformular as funções as funções da árvore pois não está construindo o comando: '< infile cmd > outfile'